### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/charatatum/b5cc286b-48d9-409d-be80-ac4d4e2bc279/a3d35e23-5966-4657-ab57-f8ddd50bb829/_apis/work/boardbadge/b0ef7ead-832f-4334-82a2-809f362f9484)](https://dev.azure.com/charatatum/b5cc286b-48d9-409d-be80-ac4d4e2bc279/_boards/board/t/a3d35e23-5966-4657-ab57-f8ddd50bb829/Microsoft.RequirementCategory)
 # Beats-R-Us
 A software for created for creatives by creatives. #fcbc 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/charatatum/b5cc286b-48d9-409d-be80-ac4d4e2bc279/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.